### PR TITLE
Add parameter to automatically initialize plugin on app load

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -21,6 +21,7 @@
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="OkHttpPlugin">
                 <param name="android-package" value="org.fathens.cordova.okhttp.InitOkHttp" />
+                <param name="onload" value="true" />
             </feature>
         </config-file>
 


### PR DESCRIPTION
The plugin would not initialize and basically have no effect. We still had crashes related to SSL after adding the plugin.

By setting the `onload` parameter to plugin.xml, the plugin is automatically initialized (debug output is visible in Android logs) and this seems to fix the SSL crashes we experienced before.
