### PR TITLE
Initialize Once

### DIFF
--- a/platforms/android/src/org/fathens/cordova/okhttp/InitOkHttp.java
+++ b/platforms/android/src/org/fathens/cordova/okhttp/InitOkHttp.java
@@ -15,11 +15,16 @@ import com.squareup.okhttp.OkHttpClient;
 
 public class InitOkHttp extends CordovaPlugin {
     private static final String TAG = "InitOkHttp";
+    private static boolean isInitialized = false;
 
     @Override
     public void initialize(CordovaInterface cordova, CordovaWebView webView) {
 	super.initialize(cordova, webView);
-	initHttp();
+
+        if (!isInitialized) {
+            initHttp();
+            isInitialized = true;
+        }
     }
 
     public void initHttp() {


### PR DESCRIPTION
Ensures that plugin is only initialized once

This prevents a crash when the application is quitted via `navigator.app.exitApp()`
and started again. Apparently the URLStreamHandlerFactory is kept in that case
which results in an error when trying to set it a second time.

Adapted from https://issues.apache.org/jira/browse/CB-7925
